### PR TITLE
Fixed comment and post functions to standardize string ID parameters

### DIFF
--- a/data/db_seed.js
+++ b/data/db_seed.js
@@ -32,6 +32,7 @@ async function main() {
         try {
             console.log('Attempting to create a user with a duplicate username (johnDoe)...');
             await createUser('johnDoe', 'AnotherPassword123!');
+            console.log("UH OH! Did not catch duplicate username!");
         } catch (error) {
             console.error('Expected error for duplicate username:', error);
         }
@@ -175,6 +176,7 @@ async function main() {
         try {
             console.log('Attempting to create a user with an invalid username...');
             await createUser('', 'InvalidPassword!');
+            console.log("UH OH! Did not catch invalid username!");
         } catch (error) {
             console.error('Expected error for invalid username:', error);
         }
@@ -182,6 +184,7 @@ async function main() {
         try {
             console.log('Attempting to fetch a user with an invalid ID...');
             await getUserById('invalidObjectId');
+            console.log("UH OH! Did not catch invalid ID!");
         } catch (error) {
             console.error('Expected error for invalid ID:', error);
         }

--- a/data/posts.js
+++ b/data/posts.js
@@ -49,7 +49,7 @@ async function createPost(title, ownerId, content, repoLink, topic_tags) {
     "ownerId": ownerId,
     "content": content,
     "repoLink": repoLink,
-    "comments": [""],
+    "comments": [],
     "createdAt": createdTime,
     "likes": 0,
     "topic_tags": topic_tags
@@ -58,34 +58,38 @@ async function createPost(title, ownerId, content, repoLink, topic_tags) {
   const insertInfo = await postCollection.insertOne(newPost);
   if (!insertInfo.acknowledged) throw `Could not add post`;
   // return post object
-  const newId = insertInfo.insertedId;
+  const newId = insertInfo.insertedId.toString();
   const post = await getPostById(newId);
   return post;
 }
 
 /**
  * This function retrieves all posts from the database
- * @returns {Array<Post>} posts
- * @throws {Error} if no posts are found
+ * @returns {Array<Post>} posts, or empty list if no posts are found
  * */
 async function getAllPosts() {
   const postCollection = await projectPosts();
   const posts = await postCollection.find({}).toArray();
-  if (!posts) throw `No posts found`;
+  if (!posts) return [];
+  posts = posts.map((element) => {
+		element._id = element._id.toString();
+		return element;
+	});
   return posts;
 }
 
 /**
  * This function retrieves a post by its ID
  * @param {string} postId
- * @returns {Post} post
+ * @returns {Object} post
  * @throws {Error} if post is not found
  * */
 async function getPostById(postId) {
-  postId = stringVal(postId, 'postId', 'getPostById');
+  postId = idVal(postId, 'postId', 'getPostById');
   const postCollection = await projectPosts();
   const post = await postCollection.findOne({_id: new ObjectId(postId)});
   if (!post) throw `No post with that id: ${postId}`;
+  post._id = post._id.toString();
   return post;
 }
 
@@ -96,10 +100,14 @@ async function getPostById(postId) {
  * @throws {Error} if no posts are found for the user
  */
 async function getPostsByUserId(ownerId) {
-  ownerId = stringVal(ownerId, 'ownerId', 'getPostsByUserId');
+  ownerId = idVal(ownerId, 'ownerId', 'getPostsByUserId');
   const postCollection = await projectPosts();
   const posts = await postCollection.find({ ownerId: new ObjectId(ownerId) }).toArray();
   if (!posts || posts.length === 0) throw `No posts found for user with id: ${ownerId}`;
+  posts = posts.map((element) => {
+		element._id = element._id.toString();
+		return element;
+	});
   return posts;
 }
 
@@ -110,7 +118,7 @@ async function getPostsByUserId(ownerId) {
  * @throws {Error} if post is not found
  * */
 async function removePost(postId){
-  postId = stringVal(postId, 'postId', 'removePost');
+  postId = idVal(postId, 'postId', 'removePost');
   const postCollection = await projectPosts();
   const deletionInfo = await postCollection.deleteOne({_id: new ObjectId(postId)});
   if (deletionInfo.deletedCount === 0) throw `Could not delete post with id of ${postId}`;
@@ -127,7 +135,7 @@ async function removePost(postId){
 
 // IDK if we wanna do an dict of field:update but yeah???
 async function updatePost(postId, updateData) {
-  postId = stringVal(postId, 'postId', 'updatePost');
+  postId = idVal(postId, 'postId', 'updatePost');
   const postCollection = await projectPosts();
   const updateInfo = await postCollection.updateOne(
     {_id: new ObjectId(postId)},
@@ -148,6 +156,10 @@ async function grabfilteredPosts(tags){
   const postCollection = await projectPosts();
   const posts = await postCollection.find({topic_tags: {$in: tags}}).toArray();
   if (!posts) throw `No posts with that tag`;
+  posts = posts.map((element) => {
+	  element._id = element._id.toString();
+		return element;
+	});
   return posts;
 }
 


### PR DESCRIPTION
Fixed comment data functions to work as intended with the database structure. Also, modified both comment and post functions to standardize using strings for ID parameters and not ObjectIDs, like how users mostly does it. Lastly, added more console logging to the db_seed file when expected errors are NOT caught.